### PR TITLE
Add nix based k8s scanning tools

### DIFF
--- a/OperatingSystem-Services/Service-Containers/Kubernetes/Resources/Scanning/.envrc
+++ b/OperatingSystem-Services/Service-Containers/Kubernetes/Resources/Scanning/.envrc
@@ -1,0 +1,3 @@
+source_url "https://raw.githubusercontent.com/cachix/devenv/82c0147677e510b247d8b9165c54f73d32dfd899/direnvrc" "sha256-7u4iDd1nZpxL4tCzmPG0dQgC5V+/44Ba+tHkPob1v2k="
+
+use devenv

--- a/OperatingSystem-Services/Service-Containers/Kubernetes/Resources/Scanning/.gitignore
+++ b/OperatingSystem-Services/Service-Containers/Kubernetes/Resources/Scanning/.gitignore
@@ -1,0 +1,9 @@
+# Devenv
+.devenv*
+devenv.local.nix
+
+# direnv
+.direnv
+
+# pre-commit
+.pre-commit-config.yaml

--- a/OperatingSystem-Services/Service-Containers/Kubernetes/Resources/Scanning/devenv.lock
+++ b/OperatingSystem-Services/Service-Containers/Kubernetes/Resources/Scanning/devenv.lock
@@ -1,0 +1,100 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1737028622,
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "4e5b00134bf03f16af6b25b80abb38c598cfe239",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1733328505,
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1733477122,
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "7bd9e84d0452f6d2e63b6e6da29fe73fac951857",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1737043064,
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "94ee657f6032d913fe0ef49adaa743804635b0bb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/OperatingSystem-Services/Service-Containers/Kubernetes/Resources/Scanning/devenv.nix
+++ b/OperatingSystem-Services/Service-Containers/Kubernetes/Resources/Scanning/devenv.nix
@@ -1,0 +1,57 @@
+{ pkgs, lib, config, inputs, ... }:
+
+{
+  # https://devenv.sh/basics/
+  env.GREET = "devenv";
+
+  # https://devenv.sh/packages/
+  # This is where we add packages that we want in this directory, just save and exit to apply or use 'devenv shell'
+  packages = with pkgs; [
+    git
+    kubecm
+    kubeval
+    kubectl
+    kubescape
+    kube-hunter
+  ];
+
+  # https://devenv.sh/languages/
+  # languages.rust.enable = true;
+
+  # https://devenv.sh/processes/
+  # processes.cargo-watch.exec = "cargo-watch";
+
+  # https://devenv.sh/services/
+  # services.postgres.enable = true;
+
+  # https://devenv.sh/scripts/
+  scripts.hello.exec = ''
+    echo hello from $GREET
+  '';
+  # Follow this format to add more scripts, the following script just lists all resources in the cluster
+  scripts.check-all.exec = ''
+    sudo kubectl get all -A
+  '';
+
+  enterShell = ''
+    hello
+    git --version
+  '';
+
+  # https://devenv.sh/tasks/
+  # tasks = {
+  #   "myproj:setup".exec = "mytool build";
+  #   "devenv:enterShell".after = [ "myproj:setup" ];
+  # };
+
+  # https://devenv.sh/tests/
+  enterTest = ''
+    echo "Running tests"
+    git --version | grep --color=auto "${pkgs.git.version}"
+  '';
+
+  # https://devenv.sh/pre-commit-hooks/
+  # pre-commit.hooks.shellcheck.enable = true;
+
+  # See full reference at https://devenv.sh/reference/options/
+}

--- a/OperatingSystem-Services/Service-Containers/Kubernetes/Resources/Scanning/devenv.yaml
+++ b/OperatingSystem-Services/Service-Containers/Kubernetes/Resources/Scanning/devenv.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://devenv.sh/devenv.schema.json
+inputs:
+  nixpkgs:
+    url: github:cachix/devenv-nixpkgs/rolling
+
+# If you're using non-OSS software, you can set allowUnfree to true.
+# allowUnfree: true
+
+# If you're willing to use a package that's vulnerable
+# permittedInsecurePackages:
+#  - "openssl-1.1.1w"
+
+# If you have more than one devenv you can merge them
+#imports:
+# - ./backend

--- a/OperatingSystem-Services/Service-Containers/Kubernetes/Resources/Scanning/nix-install.md
+++ b/OperatingSystem-Services/Service-Containers/Kubernetes/Resources/Scanning/nix-install.md
@@ -1,11 +1,13 @@
-# Installing nix
+# Nix Environment Setup
+
+## Installing nix
 
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | \
   sh -s -- install
 ```
 
-# Using devenv and direnv
+## Using devenv and direnv
 
 To install them to the system use:
 

--- a/OperatingSystem-Services/Service-Containers/Kubernetes/Resources/Scanning/nix-install.md
+++ b/OperatingSystem-Services/Service-Containers/Kubernetes/Resources/Scanning/nix-install.md
@@ -1,0 +1,21 @@
+# Installing nix
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | \
+  sh -s -- install
+```
+
+# Using devenv and direnv
+
+To install them to the system use:
+
+```bash
+nix profile install nixpkgs#direnv
+nix profile install nixpkgs#devenv
+```
+
+To manually activate the shell just run:
+
+```bash
+devenv shell
+```


### PR DESCRIPTION
## Overview of Changes

General overview of what has been changed
```
This commit brings a md file holding some commands to install nix on any system, devenv to make isolated dev environments that comes with untempered tools, and direnv to load and unload those environments upon moving through directories.
```

## Reason for Modification

This is useful since having access to nix allow us to have reproducible environments and we can create local scripts to help automate some checks, later we could add things to quickly secure the system.

## Verification

- [x] The documentation is completed, or does not contain work-in-progress/partially-completed sections.
- [x] The documentation is written in *Markdown* (Exception for Inject and Incident Reports).
- [x] Any Images are contained in a subdirectory `Images`.
- [x] Any scripts, Ansible Playbooks, Terraform scripts, etc. Have documentation explaining their purpose and use case.
- [x] Any scripts are tested.
- [x] I have assigned and notified a reviewer.